### PR TITLE
Add streaming enabled support

### DIFF
--- a/src/client/Wallstick/CharacterHelper.luau
+++ b/src/client/Wallstick/CharacterHelper.luau
@@ -186,8 +186,6 @@ function CharacterHelper.findStreamingFocus(player: Player): StreamingFocus?
 	local alignPosition = streamingFocus and streamingFocus:FindFirstChildWhichIsA("AlignPosition")
 	local alignOrientation = streamingFocus and streamingFocus:FindFirstChildWhichIsA("AlignOrientation")
 
-	print(wallstickModel, streamingFoci, streamingFocus, alignPosition, alignOrientation)
-
 	if streamingFocus and streamingFocus:IsA("BasePart") and alignPosition and alignOrientation then
 		return {
 			part = streamingFocus,

--- a/src/client/Wallstick/CharacterHelper.luau
+++ b/src/client/Wallstick/CharacterHelper.luau
@@ -172,6 +172,33 @@ function CharacterHelper.setMyPerformer(real: Model, fake: Model?)
 	animateController.matchAnimate(humanoid)
 end
 
+export type StreamingFocus = {
+	part: BasePart,
+	alignPosition: AlignPosition,
+	alignOrientation: AlignOrientation,
+}
+
+function CharacterHelper.findStreamingFocus(player: Player): StreamingFocus?
+	local wallstickModel = workspace:FindFirstChild("Wallstick")
+	local streamingFoci = wallstickModel and wallstickModel:FindFirstChild("StreamingFoci")
+
+	local streamingFocus = streamingFoci and streamingFoci:FindFirstChild(`StreamingFocus_{player.UserId}`)
+	local alignPosition = streamingFocus and streamingFocus:FindFirstChildWhichIsA("AlignPosition")
+	local alignOrientation = streamingFocus and streamingFocus:FindFirstChildWhichIsA("AlignOrientation")
+
+	print(wallstickModel, streamingFoci, streamingFocus, alignPosition, alignOrientation)
+
+	if streamingFocus and streamingFocus:IsA("BasePart") and alignPosition and alignOrientation then
+		return {
+			part = streamingFocus,
+			alignPosition = alignPosition,
+			alignOrientation = alignOrientation,
+		}
+	end
+
+	return nil
+end
+
 --
 
 return CharacterHelper

--- a/src/client/Wallstick/init.luau
+++ b/src/client/Wallstick/init.luau
@@ -64,6 +64,7 @@ export type Wallstick = typeof(setmetatable(
 
 		real: CharacterHelper.RealCharacter,
 		fake: CharacterHelper.FakeCharacter,
+		streamingFocus: CharacterHelper.StreamingFocus,
 	},
 	WallstickClass
 ))
@@ -93,6 +94,7 @@ function WallstickClass.new(options: Options): Wallstick
 
 	self.real = CharacterHelper.real(Players.LocalPlayer)
 	self.fake = CharacterHelper.fake(Players.LocalPlayer)
+	self.streamingFocus = assert(CharacterHelper.findStreamingFocus(Players.LocalPlayer), "No streaming focus found.")
 
 	self.trove:Add(CharacterHelper.applyCollisionGroup(self.real.character, "WallstickNoCollision"))
 
@@ -140,6 +142,10 @@ function WallstickClass.new(options: Options): Wallstick
 
 		self.real.humanoid.EvaluateStateMachine = true
 		self.real.rootPart.Anchored = false
+
+		self.streamingFocus.part.CFrame = self.options.origin
+		self.streamingFocus.alignPosition.Position = self.options.origin.Position
+		self.streamingFocus.alignOrientation.CFrame = self.options.origin
 	end)
 
 	return self
@@ -259,11 +265,15 @@ end
 
 function WallstickClass._stepRenderCharacter(self: Wallstick, _dt: number)
 	local realRootCF = self:_getCalculatedRealRootCFrame()
+	local fakeRootCF = self.fake.rootPart.CFrame
 	local rootCameraOffset = realRootCF:ToObjectSpace(workspace.CurrentCamera.CFrame)
-	local geometryCameraCF = self.fake.rootPart.CFrame * rootCameraOffset
+	local geometryCameraCF = fakeRootCF * rootCameraOffset
 
 	self.fake.humanoid.Jump = self.real.humanoid.Jump
 	self.fake.humanoid:Move(GravityCamera.getMoveVector(geometryCameraCF), false)
+
+	self.streamingFocus.alignPosition.Position = fakeRootCF.Position
+	self.streamingFocus.alignOrientation.CFrame = fakeRootCF
 
 	if GravityCamera.getRotationType() == Enum.RotationType.CameraRelative then
 		local right = GravityCamera.getMoveVector(geometryCameraCF, Vector3.xAxis)

--- a/src/client/clientEntry.client.luau
+++ b/src/client/clientEntry.client.luau
@@ -24,9 +24,12 @@ local function ignoreCharacterParts(result: RaycastResult)
 end
 
 local function onCharacterAdded(character: Model)
+	local wallstickModel = workspace:WaitForChild("Wallstick") :: Model
+	local wallstickOrigin = wallstickModel:WaitForChild("Origin") :: BasePart
+
 	local wallstick = WallstickClass.new({
-		parent = workspace:WaitForChild("Wallstick"),
-		origin = CFrame.new(2000, 0, 0),
+		parent = wallstickModel,
+		origin = wallstickOrigin.CFrame,
 		retainWorldVelocity = true,
 		camera = {
 			tilt = true,
@@ -73,8 +76,6 @@ local function onCharacterAdded(character: Model)
 	simulationConnection:Disconnect()
 	wallstick:Destroy()
 end
-
-assert(not workspace.StreamingEnabled, "Wallstick does not support streaming enabled.")
 
 if Players.LocalPlayer.Character then
 	onCharacterAdded(Players.LocalPlayer.Character)

--- a/src/server/init.server.luau
+++ b/src/server/init.server.luau
@@ -20,28 +20,77 @@ local function setupCollisions()
 	PhysicsService:CollisionGroupSetCollidable("WallstickCollision", "WallstickCollision", true)
 end
 
+local function createReplicationFocus(player: Player, originCF: CFrame, parent: Instance)
+	local part = Instance.new("Part")
+	part.Name = `StreamingFocus_{player.UserId}`
+	part.Transparency = 1
+	part.CanCollide = false
+	part.CanTouch = false
+	part.CanQuery = false
+	part.Size = Vector3.new(1, 1, 1)
+	part.CFrame = originCF
+	part.Parent = parent
+
+	local attach = Instance.new("Attachment")
+	attach.Parent = part
+
+	local alignPosition = Instance.new("AlignPosition")
+	alignPosition.Enabled = true
+	alignPosition.MaxVelocity = 10_000_000
+	alignPosition.Responsiveness = 200
+	alignPosition.Position = originCF.Position
+	alignPosition.Mode = Enum.PositionAlignmentMode.OneAttachment
+	alignPosition.Attachment0 = attach
+	alignPosition.Parent = part
+
+	local alignOrientation = Instance.new("AlignOrientation")
+	alignOrientation.Enabled = true
+	alignOrientation.MaxTorque = 10_000_000
+	alignOrientation.Responsiveness = 200
+	alignOrientation.CFrame = originCF
+	alignOrientation.Mode = Enum.OrientationAlignmentMode.OneAttachment
+	alignOrientation.Attachment0 = attach
+	alignOrientation.Parent = part
+
+	if workspace.StreamingEnabled then
+		player:AddReplicationFocus(part)
+	end
+
+	part:SetNetworkOwner(player)
+
+	local connection
+	connection = Players.PlayerRemoving:Connect(function(leavingPlayer)
+		if leavingPlayer == player then
+			connection:Disconnect()
+			part:Destroy()
+		end
+	end)
+end
+
 local function setupWallstickModel()
 	local wallstickModel = Instance.new("Model")
 	wallstickModel.Name = "Wallstick"
 	wallstickModel.ModelStreamingMode = Enum.ModelStreamingMode.Persistent
 	wallstickModel.Parent = workspace
 
-	local wallstickOrigin = Instance.new("Part")
-	wallstickOrigin.Name = "Origin"
-	wallstickOrigin.CFrame = CFrame.new(2000, 0, 0)
-	wallstickOrigin.Size = Vector3.new(1, 1, 1)
-	wallstickOrigin.Transparency = 1
-	wallstickOrigin.Anchored = true
-	wallstickOrigin.CanCollide = false
-	wallstickOrigin.CanTouch = false
-	wallstickOrigin.CanQuery = false
-	wallstickOrigin.Parent = wallstickModel
+	local origin = Instance.new("Part")
+	origin.Name = "Origin"
+	origin.CFrame = CFrame.new(2000, 0, 0)
+	origin.Size = Vector3.new(1, 1, 1)
+	origin.Transparency = 1
+	origin.Anchored = true
+	origin.CanCollide = false
+	origin.CanTouch = false
+	origin.CanQuery = false
+	origin.Parent = wallstickModel
 
-	if workspace.StreamingEnabled then
-		Players.PlayerAdded:Connect(function(player)
-			player:AddReplicationFocus(wallstickOrigin)
-		end)
-	end
+	local streamingFoci = Instance.new("Folder")
+	streamingFoci.Name = "StreamingFoci"
+	streamingFoci.Parent = wallstickModel
+
+	Players.PlayerAdded:Connect(function(player)
+		createReplicationFocus(player, origin.CFrame, streamingFoci)
+	end)
 end
 
 --

--- a/src/server/init.server.luau
+++ b/src/server/init.server.luau
@@ -1,5 +1,6 @@
 --!strict
 
+local Players = game:GetService("Players") :: Players
 local PhysicsService = game:GetService("PhysicsService") :: PhysicsService
 
 local PlayerScripts = require(script.PlayerScripts)
@@ -19,13 +20,34 @@ local function setupCollisions()
 	PhysicsService:CollisionGroupSetCollidable("WallstickCollision", "WallstickCollision", true)
 end
 
---
+local function setupWallstickModel()
+	local wallstickModel = Instance.new("Model")
+	wallstickModel.Name = "Wallstick"
+	wallstickModel.ModelStreamingMode = Enum.ModelStreamingMode.Persistent
+	wallstickModel.Parent = workspace
 
-local wallstickFolder = Instance.new("Folder")
-wallstickFolder.Name = "Wallstick"
-wallstickFolder.Parent = workspace
+	local wallstickOrigin = Instance.new("Part")
+	wallstickOrigin.Name = "Origin"
+	wallstickOrigin.CFrame = CFrame.new(2000, 0, 0)
+	wallstickOrigin.Size = Vector3.new(1, 1, 1)
+	wallstickOrigin.Transparency = 1
+	wallstickOrigin.Anchored = true
+	wallstickOrigin.CanCollide = false
+	wallstickOrigin.CanTouch = false
+	wallstickOrigin.CanQuery = false
+	wallstickOrigin.Parent = wallstickModel
+
+	if workspace.StreamingEnabled then
+		Players.PlayerAdded:Connect(function(player)
+			player:AddReplicationFocus(wallstickOrigin)
+		end)
+	end
+end
+
+--
 
 PlayerScripts.setup()
 setupCollisions()
+setupWallstickModel()
 
 Replication.listenServer()


### PR DESCRIPTION
This PR adds streaming enabled support to rbx-wallstick.  Previously streaming was unsupported since the "fake" world was out of the player's streaming radius which would cause physics (even on local instances) to not simulate.

A fast solution that solves 99% of cases can be implemented as such: Add a new static origin part that always sits at the center of the fake world and then add that part to the player's replication foci. This works relatively well because the fake player rarely gets far from the static replication foci. However, if the developer were to refrain from updating the part the player's stuck to and / or the player managed to travel outside the streaming radius this could cause problems.

As such a more proper solution is implemented. We add a part on the server with client ownership. This part is set as as a replication foci and moved alongside the fake character on the client to ensure the streaming radius always originates from the center of the fake character.