### PR TITLE
Fix death tracking

### DIFF
--- a/src/client/Wallstick/init.luau
+++ b/src/client/Wallstick/init.luau
@@ -96,7 +96,7 @@ function WallstickClass.new(options: Options): Wallstick
 
 	self.trove:Add(CharacterHelper.applyCollisionGroup(self.real.character, "WallstickNoCollision"))
 
-	self.real.humanoid.EvaluateStateMachine = false
+	self.real.humanoid.PlatformStand = true
 	self.real.rootPart.Anchored = false
 
 	self.fake.character.Parent = self.options.parent


### PR DESCRIPTION
This PR fixes the wallstick controller not properly cleaning up when the player dies.

This was an issue because when `humanoid.EvaluateStateMachine = true` the `humanoid.Died` event does not fire. Using platform stand instead has the same end-result, but the event properly fires making this a very simple fix.